### PR TITLE
Change prec_mm field of Forecast model to float

### DIFF
--- a/yaweather/models/forecast.py
+++ b/yaweather/models/forecast.py
@@ -94,7 +94,7 @@ class Forecast(Base):
     # Humidity (percent)
     humidity: Optional[float] = None
     # Predicted amount of precipitation (mm)
-    prec_mm: Optional[int] = None
+    prec_mm: Optional[float] = None
     # Predicted duration of precipitation (minutes)
     prec_period: Optional[int] = None
     # Type of precipitation


### PR DESCRIPTION
Seems like at least for informers Yandex Weather Forecasts API returns float value for prec_mm field in parts forecast. At least checked with 3 towns (Moscow, SaintPetersburg, Ivanovo).